### PR TITLE
Handle deleted issues and deploy pages

### DIFF
--- a/.github/workflows/blog-post-generator.yml
+++ b/.github/workflows/blog-post-generator.yml
@@ -2,12 +2,13 @@ name: Blog post generator
 
 on:
   issues:
-    types: [opened, edited, reopened, labeled, unlabeled]
+    types: [opened, edited, reopened, labeled, unlabeled, deleted]
   workflow_dispatch:
 
 permissions:
   contents: write
   issues: write
+  actions: write
 
 jobs:
   guard_issue:
@@ -70,3 +71,20 @@ jobs:
           else
             echo "No changes to commit"
           fi
+
+  trigger_pages_deploy:
+    needs: generate_site
+    if: needs.generate_site.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Pages deployment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'static.yml',
+              ref: context.ref,
+            });

--- a/scripts/generate_blog.py
+++ b/scripts/generate_blog.py
@@ -144,6 +144,16 @@ def render_post(issue: Mapping[str, str]) -> str:
 </html>"""
 
 
+def remove_stale_posts(valid_slugs: set[str]) -> None:
+    """删除已不存在的 Issue 对应的文章文件"""
+    if not POST_DIR.exists():
+        return
+
+    for post_file in POST_DIR.glob("*.html"):
+        if post_file.stem not in valid_slugs:
+            post_file.unlink()
+
+
 def write_post_files(issues: Iterable[Mapping[str, str]]) -> List[Mapping[str, str]]:
     """将每个 Issue 渲染成 HTML 文件并保存"""
     POST_DIR.mkdir(parents=True, exist_ok=True)
@@ -265,6 +275,7 @@ def generate() -> None:
     print(f"Found {len(issues)} issues.")
     
     post_metadata = write_post_files(issues)
+    remove_stale_posts({post["slug"] for post in post_metadata})
     author = load_author_config()
     write_site_files(post_metadata, author)
     print("Blog generated successfully.")


### PR DESCRIPTION
## Summary
- trigger the Pages deployment workflow after generating blog content
- include issue deletion events so removed issues regenerate the site
- clean up stale post files when issues are removed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6929a9741ba483339cc87d8617b2393d)