### PR TITLE
Add math symbol support and table styling

### DIFF
--- a/markdown.py
+++ b/markdown.py
@@ -13,6 +13,24 @@ from typing import List, Optional
 
 LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
+MATH_SYMBOLS = {
+    r"\\wedge": "∧",
+    r"\\vee": "∨",
+    r"\\land": "∧",
+    r"\\lor": "∨",
+    r"\\neg": "¬",
+    r"\\to": "→",
+    r"\\rightarrow": "→",
+    r"\\leftarrow": "←",
+    r"\\leftrightarrow": "↔",
+}
+
+
+def _escape_with_math(text: str) -> str:
+    for pattern, symbol in MATH_SYMBOLS.items():
+        text = re.sub(pattern, symbol, text)
+    return html.escape(text)
+
 
 def _render_inline(text: str) -> str:
     segments: List[str] = []
@@ -20,12 +38,15 @@ def _render_inline(text: str) -> str:
     for match in LINK_PATTERN.finditer(text):
         start, end = match.span()
         if start > last:
-            segments.append(html.escape(text[last:start]))
+            segments.append(_escape_with_math(text[last:start]))
         label, url = match.groups()
-        segments.append(f"<a href=\"{html.escape(url)}\" target=\"_blank\">{html.escape(label)}</a>")
+        safe_label = _escape_with_math(label)
+        segments.append(
+            f"<a href=\"{html.escape(url)}\" target=\"_blank\">{safe_label}</a>"
+        )
         last = end
     if last < len(text):
-        segments.append(html.escape(text[last:]))
+        segments.append(_escape_with_math(text[last:]))
     return "".join(segments)
 
 

--- a/style.css
+++ b/style.css
@@ -183,6 +183,38 @@ a {
   border: 1px solid var(--border);
 }
 
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.article-body th,
+.article-body td {
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+.article-body thead th {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.article-body th:nth-child(odd),
+.article-body td:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.article-body th:nth-child(even),
+.article-body td:nth-child(even) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .article-body pre {
   background: rgba(0, 0, 0, 0.6);
   padding: 14px;

--- a/styles/cartoon.css
+++ b/styles/cartoon.css
@@ -184,6 +184,38 @@ a {
   border: 1px solid var(--border);
 }
 
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.article-body th,
+.article-body td {
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+.article-body thead th {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.article-body th:nth-child(odd),
+.article-body td:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.article-body th:nth-child(even),
+.article-body td:nth-child(even) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .article-body pre {
   background: rgba(0, 0, 0, 0.6);
   padding: 14px;

--- a/styles/cubism.css
+++ b/styles/cubism.css
@@ -184,6 +184,38 @@ a {
   border: 1px solid var(--border);
 }
 
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.article-body th,
+.article-body td {
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+.article-body thead th {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.article-body th:nth-child(odd),
+.article-body td:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.article-body th:nth-child(even),
+.article-body td:nth-child(even) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .article-body pre {
   background: rgba(0, 0, 0, 0.6);
   padding: 14px;

--- a/styles/default.css
+++ b/styles/default.css
@@ -183,6 +183,38 @@ a {
   border: 1px solid var(--border);
 }
 
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.article-body th,
+.article-body td {
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+.article-body thead th {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.article-body th:nth-child(odd),
+.article-body td:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.article-body th:nth-child(even),
+.article-body td:nth-child(even) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .article-body pre {
   background: rgba(0, 0, 0, 0.6);
   padding: 14px;

--- a/styles/retro.css
+++ b/styles/retro.css
@@ -184,6 +184,38 @@ a {
   border: 1px solid var(--border);
 }
 
+.article-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.article-body th,
+.article-body td {
+  padding: 10px 12px;
+  text-align: left;
+  border: 1px solid var(--border);
+}
+
+.article-body thead th {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.article-body th:nth-child(odd),
+.article-body td:nth-child(odd) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.article-body th:nth-child(even),
+.article-body td:nth-child(even) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
 .article-body pre {
   background: rgba(0, 0, 0, 0.6);
   padding: 14px;


### PR DESCRIPTION
## Summary
- replace basic LaTeX-style logic operators with Unicode symbols during markdown rendering
- add consistent table styling with alternating cell backgrounds across all theme styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6932555b0aec8333af25bb803c7ff936)